### PR TITLE
Change url for geoSolutions repository to https://...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
         <!-- for geoserver manager -->
         <repository>
             <id>GeoSolutions</id>
-            <url>http://maven.geo-solutions.it/</url>
+            <url>https://maven.geo-solutions.it/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
With Maven 3.8.1 http-connections are considered insecure and are blocked by default, causing the installation with 'mvn clean install' to fail.
Source: https://stackoverflow.com/questions/67833372/getting-blocked-mirror-for-repositories-maven-error-even-after-adding-mirrors

Luckily the geoSolutions repository is available in both http ( http://maven.geo-solutions.it/ ) and https ( https://maven.geo-solutions.it/ ) so we don't have to actually use the solutions suggested in the thread.